### PR TITLE
update text label

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,16 +12,16 @@
     <h1 class="text-4xl font-extrabold mb-6 text-accent border-b-4 border-accent pb-2">gpt-image-1 画像加工デモ</h1>
     <div class="grid grid-cols-1 gap-4">
       <div>
-        <label>Azure OpenAI アカウント名</label>
-        <input type="text" id="accountName" class="border rounded p-2 mt-1 w-full" placeholder="アカウント名">
+        <label>Azure OpenAI リソース名</label>
+        <input type="text" id="accountName" class="border rounded p-2 mt-1 w-full" placeholder="Azure OpenAI Service リソース名">
       </div>
       <div>
         <label>API キー</label>
         <input type="password" id="apiKey" class="border rounded p-2 mt-1 w-full" placeholder="API キー">
       </div>
       <div>
-        <label>デプロイ名</label>
-        <input type="text" id="deploymentName" class="border rounded p-2 mt-1 w-full" placeholder="デプロイ名">
+        <label>gpt-image-1 モデルのデプロイ名</label>
+        <input type="text" id="deploymentName" class="border rounded p-2 mt-1 w-full" placeholder="gpt-image-1 モデルのデプロイ名">
       </div>
       <div>
         <label>参照画像アップロード</label>


### PR DESCRIPTION
「リソース名」のことを「アカウント名」と書いていたりして、わかりづらい部分があったので、テキストラベルを Azure OpenAI の正式なリソース名に置き換え。